### PR TITLE
maDMPにエラーが含まれて出力されてしまう件について対応

### DIFF
--- a/maDMP.ipynb
+++ b/maDMP.ipynb
@@ -24,7 +24,8 @@
     "# DMP情報\n",
     "field = '%v'\n",
     "dataSize = '%v'\n",
-    "datasetStructure = '%v'"
+    "datasetStructure = '%v'",
+    "useDocker = '%v'"
    ]
   },
   {


### PR DESCRIPTION
## やったこと

FB58の対応でコード付帯で起動した際に、jsonのエラーが発生する問題について対応

## やらないこと

なし

## できるようになること（ユーザ目線）

コード付帯機能で起動時に、ipynb上のエラーが出ないようになる。

## できなくなること（ユーザ目線）

なし

## 動作確認の内容と結果

ローカル環境で確認し、ipynbの書式データが誤っていないことを確認した。

## その他

なし