### PR TITLE
RCOS_for_parametersをDMPから指定できるように修正

### DIFF
--- a/dmp/basic
+++ b/dmp/basic
@@ -2,4 +2,4 @@
     "field": "---",
     "dataSize": "---",
     "datasetStructure": "RCOS_with_code",
-    "useDocker": "---",
+    "useDocker": "YES",

--- a/dmp/basic
+++ b/dmp/basic
@@ -2,4 +2,4 @@
     "field": "---",
     "dataSize": "---",
     "datasetStructure": "RCOS_with_code",
-    "useDocker": "YES",
+    "useDocker": "---",

--- a/dmp/json_schema/schema_dmp_amed
+++ b/dmp/json_schema/schema_dmp_amed
@@ -29,7 +29,7 @@
       "enum": [
         "RCOS_with_code",
         "RCOS_only_data",
-        "YODA"
+        "RCOS_for_parameters"
       ]
     },
     "useDocker": {

--- a/dmp/json_schema/schema_dmp_jst
+++ b/dmp/json_schema/schema_dmp_jst
@@ -29,7 +29,7 @@
       "enum": [
         "RCOS_with_code",
         "RCOS_only_data",
-        "YODA"
+        "RCOS_for_parameters"
       ]
     },
     "useDocker": {

--- a/dmp/json_schema/schema_dmp_meti
+++ b/dmp/json_schema/schema_dmp_meti
@@ -35,7 +35,7 @@
       "enum": [
         "RCOS_with_code",
         "RCOS_only_data",
-        "YODA"
+        "RCOS_for_parameters"
       ]
     },
     "useDocker": {


### PR DESCRIPTION
## やったこと

データ構造として、RCOS_for_parametersをDMPから指定できるように修正
データ構造として、YODAを選択できないように修正

## やらないこと

なし

## できるようになること（ユーザ目線）

データ構造として、RCOS_for_parametersをDMPから指定できるようになる

## できなくなること（ユーザ目線）

データ構造として、YODAを選択できないようになる

## 動作確認の内容と結果

ローカル環境にmaDMPが生成されるところまで確認。

## その他

なし