### PR TITLE
boto3インストール設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN pip install --no-cache --upgrade pip \
     && pip install --no-cache -U nbformat==5.2.0 \
     && pip install --no-cache papermill==2.3.3 \
     && pip install --no-cache black==21.12b0 \
-    && pip install --no-cache snakemake
+    && pip install --no-cache snakemake \
+    && pip install --no-cache boto3
 
 RUN jupyter contrib nbextension install --user \
     && jupyter nbextensions_configurator enable --user \

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -15,6 +15,7 @@
 	pip install nbformat==5.2.0
 	pip install black==21.12b0
 	pip install snakemake
+	pip install boto3
 
 	# 拡張機能のインストール
 	pip install jupyter_contrib_nbextensions


### PR DESCRIPTION
## やったこと

課題管理90の対応として、S3のバケット単位でリンクを作成するためにboto3のインストールを追加した。
更新ファイルは以下。
- Dockerfile
- postBuild

## やらないこと

なし。

## できるようになること（ユーザ目線）

S3のファイル一覧取得などの処理が実行できる。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

Dockerfileとapt.txt+postBuildのそれぞれでコンテナが起動できることとboto3をimportできることを確認した。

## その他

なし。
