### PR TITLE
画像のパスをfilesのつかない相対パスに戻す

### DIFF
--- a/maDMP.ipynb
+++ b/maDMP.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "ここでは、DMPに入力いただいた情報に基づき、研究活動の支援、およびデータ管理品質向上のためにデータガバナンス機能が提供するワークフローを作成します。\n",
     "\n",
-    "![maDMP_to_workflow](../files/images/maDMP_to_workflow.jpg)\n"
+    "![maDMP_to_workflow](./images/maDMP_to_workflow.jpg)\n"
    ]
   },
   {


### PR DESCRIPTION
## やったこと

Jupyter上で画像が見えない問題があり相対パスをfilesの付くものに変更していたが、問題解決したため通常の相対パスに戻す。
html形式ではGIN上で画像が見えないことがわかったので、全てマークダウン形式に変更。

## やらないこと

なし。

## できるようになること（ユーザ目線）

GIN上でも画像を確認できる。

## できなくなること（ユーザ目線）

なし。

## 動作確認の内容と結果

既にGINにあるmaDMP.ipynbの記述を書き換えても画像が見えなかったため、
ubuntu上のGINのリポジトリでmaDMPを作成し画像が見えることを確認した。

## 水平展開（処理のモジュール化の検討を含む）の結果

workflow-templateの方の画像パスも修正。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
