### PR TITLE
バグ対応のMainブランチへの反映

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,54 @@
 FROM jupyter/scipy-notebook:ubuntu-20.04
 
 USER root
-RUN apt-get update -y \
-    && apt-get install -y netbase \
-    && apt-get install -y graphviz \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y
+RUN apt-get install -y netbase
+RUN apt-get install -y graphviz
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
 
 USER ${NB_USER}
 # mamba installを使いたかったがdatalad pushに失敗するため
 # conda installを利用している（2/2時点）
-RUN conda install --quiet --yes git==2.35.0 \
-    && conda install --quiet --yes git-annex==8.20210903 \
-    && conda clean -i -t -y
+RUN conda install --quiet --yes git==2.35.0
+RUN conda install --quiet --yes git-annex==8.20210903
+RUN conda clean -i -t -y
 
 # install the notebook package etc.
-RUN pip install --no-cache --upgrade pip \
-    && pip install --no-cache notebook \
-    && pip install --no-cache jupyter_contrib_nbextensions \
-    && pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-LC_run_through \
-    && pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs \
-    && pip install --no-cache datalad==0.17.6 \
-    && pip install --no-cache lxml==4.7.1 \
-    && pip install --no-cache blockdiag==3.0.0 \
-    && pip install --no-cache -U nbformat==5.2.0 \
-    && pip install --no-cache black==21.12b0 \
-    && pip install --no-cache snakemake \
-    && pip install --no-cache boto3 \
-    && pip install --no-cache chardet==4.0.0 \
-    && pip install --no-cache panel==0.13.1
+RUN pip install --no-cache --upgrade pip
+RUN pip install --no-cache notebook
+RUN pip install --no-cache jupyter_contrib_nbextensions
+RUN pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-LC_run_through
+RUN pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs
+RUN pip install --no-cache datalad==0.17.6
+RUN pip install --no-cache lxml==4.7.1
+RUN pip install --no-cache blockdiag==3.0.0
+RUN pip install --no-cache -U nbformat==5.2.0
+RUN pip install --no-cache black==21.12b0
+RUN pip install --no-cache snakemake
+RUN pip install --no-cache boto3
+RUN pip install --no-cache chardet==4.0.0
+RUN pip install --no-cache panel==0.13.1
 
-RUN jupyter contrib nbextension install --user \
-    && jupyter nbextensions_configurator enable --user \
-    && jupyter run-through quick-setup --user \
-    && jupyter nbextension install --py lc_multi_outputs --user \
-    && jupyter nbextension enable --py lc_multi_outputs --user
+RUN jupyter contrib nbextension install --user
+RUN jupyter nbextensions_configurator enable --user
+RUN jupyter run-through quick-setup --user
+RUN jupyter nbextension install --py lc_multi_outputs --user
+RUN jupyter nbextension enable --py lc_multi_outputs --user
 
+# upgrade nbclassic ( after nbextension installed )
+RUN pip install --no-cache nbclassic==0.4.8
 
 # install Japanese-font (for blockdiag)
 ARG font_deb=fonts-ipafont-gothic_00303-18ubuntu1_all.deb
-RUN mkdir ${HOME}/.fonts \
-    && wget -P ${HOME}/.fonts http://archive.ubuntu.com/ubuntu/pool/universe/f/fonts-ipafont/${font_deb} \
-    && dpkg-deb -x ${HOME}/.fonts/${font_deb} ~/.fonts \
-    && cp ~/.fonts/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf ~/.fonts/ipag.ttf \
-    && rm ${HOME}/.fonts/${font_deb} \
-    && rm -rf ${HOME}/.fonts/etc ${HOME}/.fonts/usr \
-    && rm .wget-hsts
+RUN mkdir ${HOME}/.fonts
+RUN wget -P ${HOME}/.fonts http://archive.ubuntu.com/ubuntu/pool/universe/f/fonts-ipafont/${font_deb}
+RUN dpkg-deb -x ${HOME}/.fonts/${font_deb} ~/.fonts
+RUN cp ~/.fonts/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf ~/.fonts/ipag.ttf
+RUN rm ${HOME}/.fonts/${font_deb}
+RUN rm -rf ${HOME}/.fonts/etc ${HOME}/.fonts/usr
+RUN rm .wget-hsts
+
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,51 @@
 FROM jupyter/scipy-notebook:ubuntu-20.04
 
 USER root
-RUN apt-get update -y
-RUN apt-get install -y netbase
-RUN apt-get install -y graphviz
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y \
+    && apt-get install -y netbase \
+    && apt-get install -y graphviz \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 USER ${NB_USER}
 # mamba installを使いたかったがdatalad pushに失敗するため
 # conda installを利用している（2/2時点）
-RUN conda install --quiet --yes git==2.35.0
-RUN conda install --quiet --yes git-annex==8.20210903
-RUN conda clean -i -t -y
+RUN conda install --quiet --yes git==2.35.0 \
+    && conda install --quiet --yes git-annex==8.20210903 \
+    && conda clean -i -t -y
 
 # install the notebook package etc.
-RUN pip install --no-cache --upgrade pip
-RUN pip install --no-cache notebook
-RUN pip install --no-cache jupyter_contrib_nbextensions
-RUN pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-LC_run_through
-RUN pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs
-RUN pip install --no-cache datalad==0.17.6
-RUN pip install --no-cache lxml==4.7.1
-RUN pip install --no-cache blockdiag==3.0.0
-RUN pip install --no-cache -U nbformat==5.2.0
-RUN pip install --no-cache black==21.12b0
-RUN pip install --no-cache snakemake
-RUN pip install --no-cache boto3
-RUN pip install --no-cache chardet==4.0.0
-RUN pip install --no-cache panel==0.13.1
+RUN pip install --no-cache --upgrade pip \
+    && pip install --no-cache notebook \
+    && pip install --no-cache jupyter_contrib_nbextensions \
+    && pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-LC_run_through \
+    && pip install --no-cache git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs \
+    && pip install --no-cache datalad==0.17.6 \
+    && pip install --no-cache lxml==4.7.1 \
+    && pip install --no-cache blockdiag==3.0.0 \
+    && pip install --no-cache -U nbformat==5.2.0 \
+    && pip install --no-cache black==21.12b0 \
+    && pip install --no-cache snakemake \
+    && pip install --no-cache boto3 \
+    && pip install --no-cache chardet==4.0.0 \
+    && pip install --no-cache panel==0.13.1
 
-RUN jupyter contrib nbextension install --user
-RUN jupyter nbextensions_configurator enable --user
-RUN jupyter run-through quick-setup --user
-RUN jupyter nbextension install --py lc_multi_outputs --user
-RUN jupyter nbextension enable --py lc_multi_outputs --user
+RUN jupyter contrib nbextension install --user \
+    && jupyter nbextensions_configurator enable --user \
+    && jupyter run-through quick-setup --user \
+    && jupyter nbextension install --py lc_multi_outputs --user \
+    && jupyter nbextension enable --py lc_multi_outputs --user
 
-# upgrade nbclassic ( after nbextension installed )
-RUN pip install --no-cache nbclassic==0.4.8
 
 # install Japanese-font (for blockdiag)
 ARG font_deb=fonts-ipafont-gothic_00303-18ubuntu1_all.deb
-RUN mkdir ${HOME}/.fonts
-RUN wget -P ${HOME}/.fonts http://archive.ubuntu.com/ubuntu/pool/universe/f/fonts-ipafont/${font_deb}
-RUN dpkg-deb -x ${HOME}/.fonts/${font_deb} ~/.fonts
-RUN cp ~/.fonts/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf ~/.fonts/ipag.ttf
-RUN rm ${HOME}/.fonts/${font_deb}
-RUN rm -rf ${HOME}/.fonts/etc ${HOME}/.fonts/usr
-RUN rm .wget-hsts
-
+RUN mkdir ${HOME}/.fonts \
+    && wget -P ${HOME}/.fonts http://archive.ubuntu.com/ubuntu/pool/universe/f/fonts-ipafont/${font_deb} \
+    && dpkg-deb -x ${HOME}/.fonts/${font_deb} ~/.fonts \
+    && cp ~/.fonts/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf ~/.fonts/ipag.ttf \
+    && rm ${HOME}/.fonts/${font_deb} \
+    && rm -rf ${HOME}/.fonts/etc ${HOME}/.fonts/usr \
+    && rm .wget-hsts
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -35,6 +35,9 @@ pip install git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs
 jupyter nbextension install --py lc_multi_outputs --user
 jupyter nbextension enable --py lc_multi_outputs --user
 
+# 拡張機能インストール後に実施
+pip install nbclassic==0.4.8
+
 # フォントの用意
 font_deb=fonts-ipafont-gothic_00303-18ubuntu1_all.deb
 mkdir ${HOME}/.fonts

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -35,9 +35,6 @@ pip install git+https://github.com/NII-cloud-operation/Jupyter-multi_outputs
 jupyter nbextension install --py lc_multi_outputs --user
 jupyter nbextension enable --py lc_multi_outputs --user
 
-# 拡張機能インストール後に実施
-pip install nbclassic==0.4.8
-
 # フォントの用意
 font_deb=fonts-ipafont-gothic_00303-18ubuntu1_all.deb
 mkdir ${HOME}/.fonts

--- a/maDMP.ipynb
+++ b/maDMP.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "ここでは、DMPに入力いただいた情報に基づき、研究活動の支援、およびデータ管理品質向上のためにデータガバナンス機能が提供するワークフローを作成します。\n",
     "\n",
-    "![maDMP_to_workflow](../files/images/maDMP_to_workflow.jpg)\n"
+    "![maDMP_to_workflow](./images/maDMP_to_workflow.jpg)\n"
    ]
   },
   {


### PR DESCRIPTION
バグ対応のMainブランチへの反映。
Hotfixのブランチからmainに反映

以下、PR#30の内容を転記

## やったこと

* nbclassicのVer変更
* インストール用のRUNコマンドを分解(キャッシュが利きやすくなるため、コンテナの起動が早くなる可能性があるため)

## やらないこと

* 特になし

## できるようになること（ユーザ目線）

* filesを画像パスにつけなくても画像表示できるようになる。

## できなくなること（ユーザ目線）

* 無し

## 動作確認の内容と結果

* 該当dockerFile.aptファイルを用いた、mdx,コード付帯機能でのコンテナ起動
* 起動したコンテナでのnbextensionsの動作確認

## 水平展開（処理のモジュール化の検討を含む）の結果

* 水平展開の結果はどうだったか
　→　水平展開の対象はなし。

## その他

* nbclassicのpip install を実施後、
  jupyter nbextensionのコマンドが実行できないことが判明( ver 4.3以降にするとNG)
 そのため、jupyter nbextensionのインストール後にnbclassicのpip installを実行するようにした。

 その状態でテストを行ったところ、jupyter nbextensionは使用できているようだったため、このソースでコミットした。
![image](https://user-images.githubusercontent.com/81957555/206367740-547f3e46-e830-4c04-9399-2ba1e52dd00f.png)

2022/12/08 追記
0.4.4ではOpenできないというバグがあったため、0.4.8に変更対応
