### PR TITLE
メタデータpkgライブラリインストール in Dokcerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN pip install --no-cache chardet==4.0.0
 RUN pip install --no-cache panel==0.13.1
 RUN pip install --no-cache python-magic==0.4.27
 RUN pip install --no-cache natsort==8.3.1
+RUN pip install git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
+RUN pip install git+https://github.com/NII-DG/nii-dg.git@master
 
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextensions_configurator enable --user

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN pip install --no-cache chardet==4.0.0
 RUN pip install --no-cache panel==0.13.1
 RUN pip install --no-cache python-magic==0.4.27
 RUN pip install --no-cache natsort==8.3.1
-RUN pip install git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
-RUN pip install git+https://github.com/NII-DG/nii-dg.git@master
+RUN pip install --no-cache git+https://github.com/NII-DG/nii-dg.git@230419_8c684da
+RUN pip install --no-cache git+https://github.com/NII-DG/dg-packager.git@master
 
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextensions_configurator enable --user


### PR DESCRIPTION
# PULL REQUEST

## Background

* dg-packagerのパブリック化に伴い、DockerFileにnii-dg,dg-packagerのインストール文を追加する。
* 検証タスクでのインストール手順は廃止 

## Main Points of Modification

* DockerFileにnii-dg,dg-packagerのインストール文を追加

## Test
* DockerFileを用いて、ライブラリがインストールされていることを確認した。
![image](https://github.com/NII-DG/maDMP-template/assets/96706614/f68c759f-e7fc-4225-b2d0-8bd951b1dbff)
![image](https://github.com/NII-DG/maDMP-template/assets/96706614/aa61d09d-7190-448f-89c0-1533c81cf04b)

* 検証タスクが正常に動くことを確認した。
![image](https://github.com/NII-DG/maDMP-template/assets/96706614/5066bc57-ca3d-48cb-8a97-6996493f984c)
![image](https://github.com/NII-DG/maDMP-template/assets/96706614/8af849c4-fac4-4785-8d3e-6b747101086e)
